### PR TITLE
Fix bug importing template config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beautifulbits/boilerplate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI for generating boilerplate code out of templates",
   "main": "./src/index.js",
   "scripts": {

--- a/src/boilerplate-generator.js
+++ b/src/boilerplate-generator.js
@@ -25,7 +25,7 @@ export class BoilerplateGenerator {
 
     this.cliWorkingDir = process.cwd();
     this.templateDir = `__boilerplate__`;
-    this.boilerplateConfigFile = 'boilerplate.config.js';
+    this.boilerplateConfigFile = 'boilerplate.config.mjs';
     this.templateDirPath = `${path.join(
       this.cliWorkingDir,
       this.templateDir

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,8 @@
  * Pluralize and singularize any word.
  */
 
-import changeCase from 'change-case';
-import pluralize from 'pluralize';
+import _changeCase from 'change-case';
+import _pluralize from 'pluralize';
 
-export default { changeCase, pluralize };
+export const changeCase = _changeCase;
+export const pluralize = _pluralize;


### PR DESCRIPTION
Bugfix

- When importing the config file for the template, it needs to be a .mjs file since the project is now using ES6 modules
- Fixed exporting included helper libraries 