### PR TITLE
Fix template config file being included in generated boilerplate

### DIFF
--- a/src/boilerplate-generator.js
+++ b/src/boilerplate-generator.js
@@ -110,7 +110,7 @@ export class BoilerplateGenerator {
 
     try {
       const files = await recursiveReaddir.list(this.templateDirPath, {
-        exclude: [`boilerplate.config.js`],
+        exclude: [this.boilerplateConfigFile],
         ignoreFolders: false,
       });
       this.templateFiles = files;


### PR DESCRIPTION
**Fix**

- After changing the config file extension for a template to be `.mjs`, the config file was being included in the generated module.